### PR TITLE
CIにフォーマッターのチェック用jobも追加する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "ormolu-on-ci" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,17 +29,7 @@ jobs:
     timeout-minutes: 300
     steps:
       - uses: actions/checkout@v2
-      - uses: haskell-actions/setup@v2
+      - uses: haskell-actions/run-ormolu@v15
         with:
-          ghc-version: '9.6.4'
-          cabal-version: "3.10.2.1"
-          enable-stack: true
-          stack-version: "2.15.1"
-      - name: install ormolu
-        run: |
-          stack install ormolu
-      - name: format
-        run: |
-          ./bin/format
-          git diff --exit-code
+          ormolu-version: '0.7.2.0' # cabal.config に合わせる
     

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,21 @@ jobs:
           ssh-add ~/.ssh/id_ed25519
           ssh-keyscan -H github.com >> ~/.ssh/known_hosts
           stack test
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.6.4'
+          cabal-version: "3.10.2.1"
+          enable-stack: true
+          stack-version: "2.15.1"
+      - name: format
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_KEY_PUBLIC: ${{ secrets.SSH_KEY_PUBLIC }}
+        run: |
+          ./bin/format
+    

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [ "master", "ormolu-on-ci" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,13 +23,6 @@ jobs:
           SSH_KEY: ${{ secrets.SSH_KEY }}
           SSH_KEY_PUBLIC: ${{ secrets.SSH_KEY_PUBLIC }}
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_KEY" | tr -d '\r' > ~/.ssh/id_ed25519
-          echo "$SSH_KEY_PUBLIC" | tr -d '\r' > ~/.ssh/id_ed25519.pub
-          chmod 700 ~/.ssh/id_ed25519
-          eval $(ssh-agent -s)
-          ssh-add ~/.ssh/id_ed25519
-          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
           stack test
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,5 +31,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: haskell-actions/run-ormolu@v15
         with:
-          ormolu-version: '0.7.2.0' # cabal.config に合わせる
+          version: '0.7.2.0' # cabal.config に合わせる
     

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,4 +41,5 @@ jobs:
       - name: format
         run: |
           ./bin/format
+          git diff --exit-code
     

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,10 @@ jobs:
           cabal-version: "3.10.2.1"
           enable-stack: true
           stack-version: "2.15.1"
+      - name: install ormolu
+        run: |
+          stack install ormolu
       - name: format
-        env:
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-          SSH_KEY_PUBLIC: ${{ secrets.SSH_KEY_PUBLIC }}
         run: |
           ./bin/format
     

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -74,7 +74,7 @@ startUp = do
   pure ()
 
 onConnect ::
-  ( DynamicLogger :> es,  
+  ( DynamicLogger :> es,
     IOE :> es,
     Concurrent :> es,
     Environment :> es,

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -74,7 +74,7 @@ startUp = do
   pure ()
 
 onConnect ::
-  ( DynamicLogger :> es,
+  ( DynamicLogger :> es,  
     IOE :> es,
     Concurrent :> es,
     Environment :> es,

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,7 +37,7 @@ packages:
 #
 extra-deps:
 - location:
-  git: git@github.com:lugendre/rio-log-effectful.git
+  git: https://github.com/lugendre/rio-log-effectful.git
   commit: d7ec31819bc0b582bb5b6f049baa9098704b6004
 
 # extra-deps: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages:
 - completed:
     commit: d7ec31819bc0b582bb5b6f049baa9098704b6004
-    git: git@github.com:lugendre/rio-log-effectful.git
+    git: https://github.com/lugendre/rio-log-effectful.git
     name: rio-log-effectful
     pantry-tree:
       sha256: 366430d8a3304bd644205668249e855ecb8c2ea801c0182656774f037b34158e
@@ -14,7 +14,7 @@ packages:
     version: 0.1.0.0
   original:
     commit: d7ec31819bc0b582bb5b6f049baa9098704b6004
-    git: git@github.com:lugendre/rio-log-effectful.git
+    git: https://github.com/lugendre/rio-log-effectful.git
 snapshots:
 - completed:
     sha256: 2fdd7d3e54540062ef75ca0a73ca3a804c527dbf8a4cadafabf340e66ac4af40


### PR DESCRIPTION
# 概要

[CONTRIBUTING.md](./CONTRIBUTING.md)では、PRを送る前に ./bin/formatを実行するように指定がある。
CIにも同様のチェックを追加し、フォーマット漏れを事前に防ぐ。

# 動作検証

fork先のゆーちき個人レポのGitHub Actions で検証

- format されていない場合
  - https://github.com/yuchiki/uzi/actions/runs/8921311474/job/24501166010
  - CIが落ちる
- format されている場合
  - https://github.com/yuchiki/uzi/actions/runs/8920428861
  - CIが通る


#  大きい方針の確認

SSH鍵情報がなくてもCI検証ができるように、rio-log-effectful.gitの fetchを git方式から https方式に変更しています。

1.  [github の推奨方法](https://docs.github.com/ja/get-started/getting-started-with-git/set-up-git#connecting-over-https-recommended) は https方式の方であるから問題ないと思いますが、himanoaさんのポリシー的に問題ないか確認したく

2. 変更していい場合、本当は２PRに分けた方がきれいだし後で見返しやすい説がある。当該部分のSSH方式からHTTPS方式への変更を分けて出しなおした方がよいですか？