### PR TITLE
ModifyChannelエフェクトをリファクタリング

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
 - containers
 - network
 - aeson
+- aeson-casing
 - effectful
 - effectful-core
 - websockets

--- a/src/Data/Discord/Channel.hs
+++ b/src/Data/Discord/Channel.hs
@@ -53,7 +53,7 @@ data Channel = Channel
   deriving (Show, Eq, Generic)
 
 instance FromJSON Channel where
-  parseJSON = genericParseJSON defaultOptions {fieldLabelModifier =  drop 2 . Casing.snakeCase}
+  parseJSON = genericParseJSON defaultOptions {fieldLabelModifier = drop 2 . Casing.snakeCase}
 
 instance ToJSON Channel where
   toJSON = genericToJSON defaultOptions {fieldLabelModifier = drop 2 . Casing.snakeCase}
@@ -61,4 +61,4 @@ instance ToJSON Channel where
 makeLenses ''Channel
 
 makeChannel :: ChannelId -> ChannelType -> ChannelPosition -> ChannelName -> Maybe ChannelId -> Channel
-makeChannel  = Channel
+makeChannel = Channel

--- a/src/Data/Discord/Channel.hs
+++ b/src/Data/Discord/Channel.hs
@@ -7,6 +7,7 @@ module Data.Discord.Channel where
 
 import Control.Lens (makeLenses)
 import Data.Aeson
+import Data.Aeson.Casing qualified as Casing
 import Data.Aeson.Types (prependFailure, typeMismatch)
 import Data.Coerce
 import Data.Discord.ChannelId
@@ -46,14 +47,18 @@ data Channel = Channel
   { __id :: ChannelId,
     __type :: ChannelType,
     __position :: ChannelPosition,
-    __name :: ChannelName
+    __name :: ChannelName,
+    __parentId :: Maybe ChannelId
   }
   deriving (Show, Eq, Generic)
 
 instance FromJSON Channel where
-  parseJSON = genericParseJSON defaultOptions {fieldLabelModifier = drop 2}
+  parseJSON = genericParseJSON defaultOptions {fieldLabelModifier =  drop 2 . Casing.snakeCase}
 
 instance ToJSON Channel where
-  toJSON = genericToJSON defaultOptions {fieldLabelModifier = drop 2}
+  toJSON = genericToJSON defaultOptions {fieldLabelModifier = drop 2 . Casing.snakeCase}
 
 makeLenses ''Channel
+
+makeChannel :: ChannelId -> ChannelType -> ChannelPosition -> ChannelName -> Maybe ChannelId -> Channel
+makeChannel  = Channel

--- a/src/Data/Discord/ChannelId.hs
+++ b/src/Data/Discord/ChannelId.hs
@@ -14,3 +14,6 @@ newtype ChannelId = ChannelId T.Text
 
 coerceChannelId :: ChannelId -> T.Text
 coerceChannelId = coerce
+
+makeChannelId :: T.Text -> ChannelId
+makeChannelId = ChannelId

--- a/src/Data/Uzi/OrganizeTimes.hs
+++ b/src/Data/Uzi/OrganizeTimes.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-missing-export-lists #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 
 -- |
 -- Module: Data.Uzi.OrganizeTimes
@@ -16,7 +17,7 @@ import Data.Aeson
 import Data.Discord hiding (coerceChannelId)
 import Data.Discord.Channel
 import Data.Discord.Channel qualified as C
-import Data.Uzi.TimesChannel
+import Data.Uzi.TimesChannel qualified as TC
 import Data.Uzi.TimesChannelGroup
 import Effectful
 import Effectful.DiscordChannel
@@ -36,7 +37,8 @@ import RIO.Vector.Boxed qualified as VU
 -- 発生しうるエラーとシチュエーションは次の通りです
 --
 -- 'Data.Uzi.OrganizeTimes.FindTimesError': TIMES(A-M) TIMES(N-Z) という名前のグループチャンネルがGuildIdが指すサーバーにどちらか片方でも存在しない場合に発生します
-newtype OrganizeTimesError = FindTimesError FindTimesChannelGroupsError
+-- 'Data.Uzi.OrganizeTimes.FindChannelError: ソートしたあとに実際にDiscordに変更を反映する過程でTimesChannelに記載されているChannelIdが存在しない場合に発生します
+data OrganizeTimesError = FindTimesError FindTimesChannelGroupsError | FindChannelError ChannelId
   deriving (Show, Eq)
 
 --
@@ -59,23 +61,24 @@ organizeTimes guildId = do
   channels <- getChannels guildId
   let channelsVector = V.fromList channels :: VU.Vector C.Channel
 
-  RIO.void $ info $ RIO.displayShow $ ("channelsVector: " <> encode channelsVector)
+  RIO.void $ info $ RIO.displayShow ("channelsVector: " <> encode channelsVector)
 
   (aToM, nToZ) <- case findTimesCategories channelsVector of
     Right a -> pure a
     Left e -> throwError . FindTimesError $ e
 
-  let channelsMap = groupByFirstLetter (fromChannels channelsVector) aToM nToZ
+  let channelsMap = groupByFirstLetter (TC.fromChannels channelsVector) aToM nToZ
   let sortedChannelsMap = sortTimesChannelGroupMap channelsMap
 
-  RIO.void $ M.traverseWithKey updateChannelPositions sortedChannelsMap
+  RIO.void $ M.traverseWithKey (updateChannelPositions channelsVector) sortedChannelsMap
   where
-    updateChannelPositions :: (DiscordChannel :> es) => TimesChannelGroup -> [TimesChannel] -> Eff es ()
-    updateChannelPositions group channels = do
-      RIO.void $ evalState @Integer 1 (traverse (updateChannelPosition (coerceChannelId group)) channels)
+    updateChannelPositions :: (DiscordChannel :> es, Error OrganizeTimesError :> es) => Vector Channel -> TimesChannelGroup -> [TC.TimesChannel] -> Eff es ()
+    updateChannelPositions channels group times = do
+      RIO.void $ evalState @Integer 1 (traverse (updateChannelPosition channels (coerceChannelId group)) times)
 
-    updateChannelPosition :: (DiscordChannel :> es, State Integer :> es) => ChannelId -> TimesChannel -> Eff es ()
-    updateChannelPosition parentId tc = do
+    updateChannelPosition :: (DiscordChannel :> es, State Integer :> es, Error OrganizeTimesError :> es) => Vector Channel -> ChannelId -> TC.TimesChannel -> Eff es ()
+    updateChannelPosition channels parentId tc = do
       count <- get
-      RIO.void $ modifyChannel guildId parentId tc (ChannelPosition count)
+      channel <- maybe (throwError . FindChannelError $ tc ^. TC.id) pure (V.find (\c -> (c ^. C._id) == (tc ^. TC.id)) channels)
+      RIO.void $ modifyChannel guildId parentId channel (ChannelPosition count)
       RIO.void $ put (count + 1)

--- a/src/Data/Uzi/OrganizeTimes.hs
+++ b/src/Data/Uzi/OrganizeTimes.hs
@@ -19,6 +19,7 @@ import Data.Discord.Channel
 import Data.Discord.Channel qualified as C
 import Data.Uzi.TimesChannel qualified as TC
 import Data.Uzi.TimesChannelGroup
+import Control.Lens
 import Effectful
 import Effectful.DiscordChannel
 import Effectful.DiscordChannel.Effect (getChannels)
@@ -26,7 +27,7 @@ import Effectful.DynamicLogger (DynamicLogger)
 import Effectful.DynamicLogger.Effect (info)
 import Effectful.Error.Dynamic
 import Effectful.State.Static.Local
-import RIO
+import RIO hiding ((^.))
 import RIO.Map qualified as M
 import RIO.Vector qualified as V
 import RIO.Vector.Boxed qualified as VU
@@ -80,5 +81,8 @@ organizeTimes guildId = do
     updateChannelPosition channels parentId tc = do
       count <- get
       channel <- maybe (throwError . FindChannelError $ tc ^. TC.id) pure (V.find (\c -> (c ^. C._id) == (tc ^. TC.id)) channels)
-      RIO.void $ modifyChannel guildId parentId channel (ChannelPosition count)
+      RIO.void $ modifyChannel channel
       RIO.void $ put (count + 1)
+    changePosition :: Channel ->  ChannelId ->  ChannelPosition -> Channel
+    changePosition channel channelId position = undefined
+      -- let updatedParentId = set' (channel ^. C._)

--- a/src/Effectful/DiscordChannel/Effect.hs
+++ b/src/Effectful/DiscordChannel/Effect.hs
@@ -22,7 +22,6 @@ import Control.Lens hiding ((.=))
 import Data.Aeson
 import Data.Discord hiding (channelId)
 import Data.Discord.Channel (Channel, ChannelPosition)
-import Data.Uzi.TimesChannel (TimesChannel)
 import Effectful
 import Effectful.Dispatch.Dynamic (HasCallStack, send)
 import RIO hiding (HasCallStack, (^.))
@@ -107,8 +106,7 @@ data DiscordChannel :: Effect where
   SendMessage :: SendMessageParams -> DiscordChannel m ()
   CreateChannel :: GuildId -> CreateChannelParams -> DiscordChannel m ()
   GetChannels :: GuildId -> DiscordChannel m [Channel]
-  -- FIXME: 手抜き実装でTimesに依存していて、他のChannelを変更する時に困るのでその時にリファクタリングする
-  ModifyChannel :: GuildId -> ChannelId -> TimesChannel -> ChannelPosition -> DiscordChannel m ()
+  ModifyChannel :: GuildId -> ChannelId -> Channel -> ChannelPosition -> DiscordChannel m ()
 
 type instance DispatchOf DiscordChannel = Dynamic
 
@@ -145,7 +143,7 @@ modifyChannel ::
   -- | チャンネル情報を更新したいチャンネルのID
   ChannelId ->
   -- | 更新後のChannelの情報
-  TimesChannel ->
+  Channel ->
   -- | 更新後のチャンネルの順番
   ChannelPosition ->
   Eff es ()

--- a/src/Effectful/DiscordChannel/Effect.hs
+++ b/src/Effectful/DiscordChannel/Effect.hs
@@ -21,7 +21,7 @@ module Effectful.DiscordChannel.Effect where
 import Control.Lens hiding ((.=))
 import Data.Aeson
 import Data.Discord hiding (channelId)
-import Data.Discord.Channel (Channel, ChannelPosition)
+import Data.Discord.Channel (Channel)
 import Effectful
 import Effectful.Dispatch.Dynamic (HasCallStack, send)
 import RIO hiding (HasCallStack, (^.))
@@ -106,7 +106,7 @@ data DiscordChannel :: Effect where
   SendMessage :: SendMessageParams -> DiscordChannel m ()
   CreateChannel :: GuildId -> CreateChannelParams -> DiscordChannel m ()
   GetChannels :: GuildId -> DiscordChannel m [Channel]
-  ModifyChannel :: GuildId -> ChannelId -> Channel -> ChannelPosition -> DiscordChannel m ()
+  ModifyChannel :: Channel -> DiscordChannel m ()
 
 type instance DispatchOf DiscordChannel = Dynamic
 
@@ -138,13 +138,7 @@ getChannels guildId = send (GetChannels guildId)
 -- | チャンネルの情報を更新します
 modifyChannel ::
   (HasCallStack, DiscordChannel :> es) =>
-  -- | 更新したいチャンネルが存在するDiscordサーバーのギルドId
-  GuildId ->
-  -- | チャンネル情報を更新したいチャンネルのID
-  ChannelId ->
   -- | 更新後のChannelの情報
   Channel ->
-  -- | 更新後のチャンネルの順番
-  ChannelPosition ->
   Eff es ()
-modifyChannel guildId cId channel position = send (ModifyChannel guildId cId channel position)
+modifyChannel = send . ModifyChannel

--- a/src/Effectful/DiscordChannel/Interpreter.hs
+++ b/src/Effectful/DiscordChannel/Interpreter.hs
@@ -57,10 +57,9 @@ runDiscordChannel = interpret $ \_ -> \case
       request GET (https host /: "api" /: version /: "guilds" /: coerce guildId /: "channels") NoReqBody pr
         $ header "Authorization" ("Bot " <> encodeUtf8 token)
     unsafeEff_ . getResponseBodyAsJsonResponse $ response
-  ModifyChannel _ parentId channel pos -> do
+  ModifyChannel channel -> do
     token <- getToken
-    let payload = object ["type" .= (0 :: Integer), "position" .= C.coerceChannelPosition pos, "parent_id" .= coerceChannelId parentId]
     _ <-
-      request PATCH (https host /: "api" /: version /: "channels" /: coerceChannelId (channel ^. C._id)) (ReqBodyJson payload) ignoreResponse
+      request PATCH (https host /: "api" /: version /: "channels" /: coerceChannelId (channel ^. C._id)) (ReqBodyJson channel) ignoreResponse
         $ header "Authorization" ("Bot " <> encodeUtf8 token)
     pure ()

--- a/src/EventHandler/MessageCreateEventHandler/Help.hs
+++ b/src/EventHandler/MessageCreateEventHandler/Help.hs
@@ -13,7 +13,6 @@ module EventHandler.MessageCreateEventHandler.Help where
 
 import Control.Lens
 import Data.Discord
-import Data.Discord.Content (body)
 import Data.Discord.Response.InteractionCreateEventResponse qualified as IC
 import Data.Either.Validation
 import Effectful

--- a/test/Data/Uzi/TimesChannelGroupSpec.hs
+++ b/test/Data/Uzi/TimesChannelGroupSpec.hs
@@ -27,15 +27,14 @@ spec = describe "TimesChannelGroup" $ do
       it "should be return to Left NtoZGroupMissing" $ do
         let cs =
               RIOV.fromList
-                [ C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(A-M)") Nothing]
+                [C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(A-M)") Nothing]
         findTimesCategories cs `shouldBe` Left NtoZGroupMissing
 
     context "when vec include only nToZ group" $ do
       it "should be return to Left NtoZGroupMissing" $ do
         let cs =
               RIOV.fromList
-                [
-                 C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(N-Z)") Nothing
+                [ C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(N-Z)") Nothing
                 ]
         findTimesCategories cs `shouldBe` Left AtoMGroupMissing
 
@@ -43,9 +42,8 @@ spec = describe "TimesChannelGroup" $ do
       it "should be return to Right" $ do
         let cs =
               RIOV.fromList
-                [
-                 C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(N-Z)") Nothing,
-                 C.makeChannel (C.ChannelId "y") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(A-M)") Nothing
+                [ C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(N-Z)") Nothing,
+                  C.makeChannel (C.ChannelId "y") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(A-M)") Nothing
                 ]
         RIO.isRight (findTimesCategories cs) `shouldBe` True
 
@@ -53,9 +51,8 @@ spec = describe "TimesChannelGroup" $ do
       it "should be return to Right" $ do
         let cs =
               RIOV.fromList
-                [
-                 C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "times(n-z)") Nothing,
-                 C.makeChannel (C.ChannelId "y") C.GuildCategory (C.ChannelPosition 0) (ChannelName "times(a-m)") Nothing
+                [ C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "times(n-z)") Nothing,
+                  C.makeChannel (C.ChannelId "y") C.GuildCategory (C.ChannelPosition 0) (ChannelName "times(a-m)") Nothing
                 ]
         RIO.isRight (findTimesCategories cs) `shouldBe` True
 

--- a/test/Data/Uzi/TimesChannelGroupSpec.hs
+++ b/test/Data/Uzi/TimesChannelGroupSpec.hs
@@ -27,25 +27,15 @@ spec = describe "TimesChannelGroup" $ do
       it "should be return to Left NtoZGroupMissing" $ do
         let cs =
               RIOV.fromList
-                [ C.Channel
-                    { C.__id = C.ChannelId "x",
-                      C.__type = C.GuildCategory,
-                      C.__position = C.ChannelPosition 0,
-                      C.__name = ChannelName "TIMES(A-M)"
-                    }
-                ]
+                [ C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(A-M)") Nothing]
         findTimesCategories cs `shouldBe` Left NtoZGroupMissing
 
     context "when vec include only nToZ group" $ do
       it "should be return to Left NtoZGroupMissing" $ do
         let cs =
               RIOV.fromList
-                [ C.Channel
-                    { C.__id = C.ChannelId "x",
-                      C.__type = C.GuildCategory,
-                      C.__position = C.ChannelPosition 0,
-                      C.__name = ChannelName "TIMES(N-Z)"
-                    }
+                [
+                 C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(N-Z)") Nothing
                 ]
         findTimesCategories cs `shouldBe` Left AtoMGroupMissing
 
@@ -53,18 +43,9 @@ spec = describe "TimesChannelGroup" $ do
       it "should be return to Right" $ do
         let cs =
               RIOV.fromList
-                [ C.Channel
-                    { C.__id = C.ChannelId "x",
-                      C.__type = C.GuildCategory,
-                      C.__position = C.ChannelPosition 0,
-                      C.__name = ChannelName "TIMES(N-Z)"
-                    },
-                  C.Channel
-                    { C.__id = C.ChannelId "y",
-                      C.__type = C.GuildCategory,
-                      C.__position = C.ChannelPosition 0,
-                      C.__name = ChannelName "TIMES(A-M)"
-                    }
+                [
+                 C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(N-Z)") Nothing,
+                 C.makeChannel (C.ChannelId "y") C.GuildCategory (C.ChannelPosition 0) (ChannelName "TIMES(A-M)") Nothing
                 ]
         RIO.isRight (findTimesCategories cs) `shouldBe` True
 
@@ -72,18 +53,9 @@ spec = describe "TimesChannelGroup" $ do
       it "should be return to Right" $ do
         let cs =
               RIOV.fromList
-                [ C.Channel
-                    { C.__id = C.ChannelId "x",
-                      C.__type = C.GuildCategory,
-                      C.__position = C.ChannelPosition 0,
-                      C.__name = ChannelName "times(n-z)"
-                    },
-                  C.Channel
-                    { C.__id = C.ChannelId "y",
-                      C.__type = C.GuildCategory,
-                      C.__position = C.ChannelPosition 0,
-                      C.__name = ChannelName "times(a-m)"
-                    }
+                [
+                 C.makeChannel (C.ChannelId "x") C.GuildCategory (C.ChannelPosition 0) (ChannelName "times(n-z)") Nothing,
+                 C.makeChannel (C.ChannelId "y") C.GuildCategory (C.ChannelPosition 0) (ChannelName "times(a-m)") Nothing
                 ]
         RIO.isRight (findTimesCategories cs) `shouldBe` True
 

--- a/test/Data/Uzi/TimesChannelSpec.hs
+++ b/test/Data/Uzi/TimesChannelSpec.hs
@@ -19,29 +19,29 @@ spec = describe "TimesChannel" $ do
   describe "TC.makeTimesChannel" $ do
     context "when channel type is voice" $ do
       it "should be return Nothing" $ do
-        TC.makeTimesChannel Channel {__id = ChannelId "xxx", __type = GuildVoice, __position = ChannelPosition 10, __name = ChannelName "yyy"} `shouldBe` Nothing
+        TC.makeTimesChannel (makeChannel (ChannelId "xxx") GuildVoice (ChannelPosition 10) (ChannelName "yyy") Nothing) `shouldBe` Nothing
 
     context "when channel type is category" $ do
       it "should be return Nothing" $ do
-        TC.makeTimesChannel Channel {__id = ChannelId "xxx", __type = GuildCategory, __position = ChannelPosition 10, __name = ChannelName "yyy"} `shouldBe` Nothing
+        TC.makeTimesChannel (makeChannel (ChannelId "xxx") GuildCategory (ChannelPosition 10) (ChannelName "yyy") Nothing) `shouldBe` Nothing
 
     context "when channel type is text" $ do
       context "when it is not times channel" $ do
         it "should be return Nothing " $ do
-          TC.makeTimesChannel Channel {__id = ChannelId "xxx", __type = GuildText, __position = ChannelPosition 10, __name = ChannelName "yyy"} `shouldBe` Nothing
+          TC.makeTimesChannel (makeChannel (ChannelId "xxx") GuildText (ChannelPosition 10) (ChannelName "yyy") Nothing) `shouldBe` Nothing
 
       context "when channel name is start by times-" $ do
         it "should be return Justing TimesChannel object " $ do
-          TC.makeTimesChannel Channel {__id = ChannelId "xxx", __type = GuildText, __position = ChannelPosition 10, __name = ChannelName "times-name"} `shouldBe` Just TC.TimesChannel {TC._id = ChannelId "xxx", TC._name = TC.TimesName "name"}
-          TC.makeTimesChannel Channel {__id = ChannelId "xxx", __type = GuildText, __position = ChannelPosition 10, __name = ChannelName "times-name-foo"} `shouldBe` Just TC.TimesChannel {TC._id = ChannelId "xxx", TC._name = TC.TimesName "name-foo"}
+          TC.makeTimesChannel (makeChannel (ChannelId "xxx") GuildText (ChannelPosition 10) (ChannelName "times-name") Nothing) `shouldBe` Just TC.TimesChannel {TC._id = ChannelId "xxx", TC._name = TC.TimesName "name"}
+          TC.makeTimesChannel (makeChannel (ChannelId "xxx") GuildText (ChannelPosition 10) (ChannelName "times-name-foo") Nothing) `shouldBe` Just TC.TimesChannel {TC._id = ChannelId "xxx", TC._name = TC.TimesName "name-foo"}
 
       context "when channel name is timezunzun" $ do
         it "should be return Justing TimesChannel object " $ do
-          TC.makeTimesChannel Channel {__id = ChannelId "xxx", __type = GuildText, __position = ChannelPosition 10, __name = ChannelName "timezunzun"} `shouldBe` Just TC.TimesChannel {TC._id = ChannelId "xxx", TC._name = TC.TimesName "zunzun"}
+          TC.makeTimesChannel (makeChannel (ChannelId "xxx") GuildText (ChannelPosition 10) (ChannelName "timezunzun") Nothing) `shouldBe` Just TC.TimesChannel {TC._id = ChannelId "xxx", TC._name = TC.TimesName "zunzun"}
 
       context "when channel name is the-ny-times" $ do
         it "should be return Justing TimesChannel object " $ do
-          TC.makeTimesChannel Channel {__id = ChannelId "xxx", __type = GuildText, __position = ChannelPosition 10, __name = ChannelName "the-ny-times"} `shouldBe` Just TC.TimesChannel {TC._id = ChannelId "xxx", TC._name = TC.TimesName "ny"}
+          TC.makeTimesChannel (makeChannel (ChannelId "xxx") GuildText (ChannelPosition 10) (ChannelName "the-ny-times") Nothing) `shouldBe` Just TC.TimesChannel {TC._id = ChannelId "xxx", TC._name = TC.TimesName "ny"}
 
   describe "fromChannels" $ do
     context "when input is empty vec" $ do
@@ -50,7 +50,7 @@ spec = describe "TimesChannel" $ do
 
     context "when the input is consists exclusively of voice channels" $ do
       it "should be return empty vec" $ do
-        let channel = Channel {__id = ChannelId "", __type = GuildVoice, __position = ChannelPosition 1, __name = ChannelName "xxxx"}
+        let channel = makeChannel (ChannelId "") GuildVoice (ChannelPosition 1) (ChannelName "xxxx") Nothing
         TC.fromChannels (RV.singleton channel) `shouldBe` (RIO.mempty @(RIO.Vector TC.TimesChannel))
 
   describe "Ord" $ do

--- a/uzi.cabal
+++ b/uzi.cabal
@@ -139,6 +139,7 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       aeson
+    , aeson-casing
     , base >=4.7 && <5
     , containers
     , data-default
@@ -171,6 +172,7 @@ executable uzi-exe
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
+    , aeson-casing
     , base >=4.7 && <5
     , containers
     , data-default
@@ -220,6 +222,7 @@ test-suite uzi-test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
+    , aeson-casing
     , base >=4.7 && <5
     , containers
     , data-default


### PR DESCRIPTION
ModifyChannelは次のような問題を抱えていました。

- TimesChannelに依存している
- ParentIdの付替えや、ポジションの変更などOrganizeTimesに本来あるべき処理がModifyChannel内で行なわれていた

このPRではこれらの関心琴をModifyChannelからOrganizeTimesに移植して、他のAPIからでもModifyChannelを使いやすいようにリファクタリングします
